### PR TITLE
Jetty 9 web sockets got new API. Updated logviewer-jetty module to run with Jetty 9.2.x.

### DIFF
--- a/logviewer-jetty/pom.xml
+++ b/logviewer-jetty/pom.xml
@@ -10,7 +10,8 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<jetty-version>7.6.7.v20120910</jetty-version>
+		<jetty-version>9.2.10.v20150310</jetty-version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
@@ -38,20 +39,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-websocket</artifactId>
+			<groupId>org.eclipse.jetty.websocket</groupId>
+			<artifactId>websocket-servlet</artifactId>
 			<version>${jetty-version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.orbit</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>2.5.0.v201103041518</version>
-        </dependency>
+
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-server</artifactId>
+			<groupId>org.eclipse.jetty.websocket</groupId>
+			<artifactId>websocket-api</artifactId>
 			<version>${jetty-version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>

--- a/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogMessageWebSocket.java
+++ b/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogMessageWebSocket.java
@@ -1,0 +1,71 @@
+package org.logviewer.servlet.jetty;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.logviewer.core.LogManager;
+import org.logviewer.services.LogConfig;
+import org.logviewer.services.MessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Created by arul on 4/6/15.
+ */
+public class LogMessageWebSocket implements WebSocketListener, MessageSender {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogViewerServlet.class);
+
+    private final LogManager logManager;
+
+    public LogMessageWebSocket(LogConfig logConfig) {
+        logManager = new LogManager(logConfig, this);
+    }
+
+    private Session outbound;
+
+    @Override
+    public void onWebSocketConnect(Session outbound) {
+        LOGGER.debug("onOpen");
+        this.outbound = outbound;
+    }
+
+    @Override
+    public void onWebSocketClose(int closeCode, String message) {
+        LOGGER.debug("onClose");
+    }
+
+    @Override
+    public void onWebSocketBinary(byte[] bytes, int i, int i2) {
+
+    }
+
+    @Override
+    public void onWebSocketError(Throwable cause) {
+        cause.printStackTrace(System.err);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+
+    @Override
+    public void onWebSocketText(String messageString) {
+        LOGGER.debug("onTextMessage: {}", messageString);
+        try {
+            logManager.handleMessage(messageString);
+        } catch (IOException e) {
+            LOGGER.debug("exception", e);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void sendMessage(String messageString) throws IOException {
+        LOGGER.debug("sending message: {}", messageString);
+        outbound.getRemote().sendString(messageString);
+    }
+
+}
+

--- a/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogMessageWebSocketCreator.java
+++ b/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogMessageWebSocketCreator.java
@@ -1,0 +1,23 @@
+package org.logviewer.servlet.jetty;
+
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.logviewer.services.LogConfig;
+
+/**
+ * Created by arul on 4/6/15.
+ */
+public class LogMessageWebSocketCreator implements WebSocketCreator {
+
+    private LogMessageWebSocket logMessageWebSocket;
+
+    public LogMessageWebSocketCreator(LogConfig logConfig) {
+        this.logMessageWebSocket = new LogMessageWebSocket(logConfig);
+    }
+
+    @Override
+    public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse) {
+        return logMessageWebSocket;
+    }
+}

--- a/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogViewerServlet.java
+++ b/logviewer-jetty/src/main/java/org/logviewer/servlet/jetty/LogViewerServlet.java
@@ -1,70 +1,21 @@
 package org.logviewer.servlet.jetty;
 
-import java.io.IOException;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.eclipse.jetty.websocket.WebSocket;
-import org.eclipse.jetty.websocket.WebSocketServlet;
-import org.logviewer.core.LogManager;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.logviewer.services.LogConfig;
-import org.logviewer.services.MessageSender;
 import org.logviewer.servlet.LogConfigServlet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Provides servlet for use in Jetty 7.
+ * Provides servlet for use in Jetty 9.2.x.
  */
 public class LogViewerServlet extends WebSocketServlet {
 
     private static final long serialVersionUID = -1419426879051383553L;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogViewerServlet.class);
-    
     private final LogConfig logConfig = new LogConfigServlet(this);
 
-    private class LogMessageWebSocket implements WebSocket, WebSocket.OnTextMessage, MessageSender {
-
-        private final LogManager logManager = new LogManager(logConfig, this);
-        private WebSocket.Connection connection;
-        
-        @Override
-        public void onOpen(WebSocket.Connection connection) {
-            LOGGER.debug("onOpen");
-            this.connection = connection;
-        }
-
-        @Override
-        public void onClose(int closeCode, String message) {
-            LOGGER.debug("onClose");
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        
-        @Override
-        public void onMessage(String messageString) {
-            LOGGER.debug("onTextMessage: {}", messageString);
-            try {
-                logManager.handleMessage(messageString);
-            } catch (IOException e) {
-                LOGGER.debug("exception", e);
-            }
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        
-        @Override
-        public void sendMessage(String messageString) throws IOException {
-            LOGGER.debug("sending message: {}", messageString);
-            connection.sendMessage(messageString);
-        }
-
-    };
-
     @Override
-    public WebSocket doWebSocketConnect(HttpServletRequest request, String protocol) {
-        LOGGER.debug("creating websocket: " + protocol);
-        return new LogMessageWebSocket();
+    public void configure(WebSocketServletFactory factory) {
+        factory.setCreator(new LogMessageWebSocketCreator(logConfig));
     }
 }

--- a/logviewer-webapp/pom.xml
+++ b/logviewer-webapp/pom.xml
@@ -30,12 +30,6 @@
 			<artifactId>log4j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -103,7 +97,7 @@
 			<id>jetty</id>
 			<properties>
 				<container.name>jetty</container.name>
-				<jetty-version>7.6.7.v20120910</jetty-version>
+				<jetty-version>9.2.10.v20150310</jetty-version>
 			</properties>
 			<dependencies>
 				<dependency>
@@ -115,7 +109,7 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.mortbay.jetty</groupId>
+						<groupId>org.eclipse.jetty</groupId>
 						<artifactId>jetty-maven-plugin</artifactId>
 						<version>${jetty-version}</version>
 						<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.4</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Jetty 9 web sockets got new API. Updated logviewer-jetty module to run with the latest Jetty 9.2.x. Jetty 9.x requires Java 7. Updated pom to use 1.7.
